### PR TITLE
changed  DEVICE_ID

### DIFF
--- a/HCPBridgeESP32/src/configuration.h
+++ b/HCPBridgeESP32/src/configuration.h
@@ -8,7 +8,7 @@
     const char* STA_PASSWD = "my-wlan-passwd";
 
     // MQTT
-    #define DEVICE_ID "garage_door"
+    #define DEVICE_ID "hcpbridge"
     const char DEVICENAME[] = "Garage Door";
     const char *MQTTSERVER = "192.168.1.100";
     const int MQTTPORT = 1883;


### PR DESCRIPTION
Starting with version 2024.2.0 home assistant requires the device name to be different from the entity name.
https://developers.home-assistant.io/blog/#naming-of-mqtt-entities

#30  