### PR TITLE
Fixed a bug in MQTT messages introduced in PR #56

### DIFF
--- a/HCPBridgeESP32/src/main.cpp
+++ b/HCPBridgeESP32/src/main.cpp
@@ -488,14 +488,16 @@ void sendDiscoveryMessageForSensor(const char name[], const char topic[], const 
   doc["payload_available"] = HA_ONLINE;
   doc["payload_not_available"] = HA_OFFLINE;
   doc["unique_id"] = uid;
-  doc["state_class"] = "measurement";
   if (key == "hum") {
+    doc["state_class"] = "measurement";
     doc["unit_of_measurement"] = "%";
     doc["device_class"] = "humidity";
   } else if (key == "temp") {
+    doc["state_class"] = "measurement";
     doc["unit_of_measurement"] = "°C";
     doc["device_class"] = "temperature";
   } else if (key == "pres") {
+    doc["state_class"] = "measurement";
     doc["unit_of_measurement"] = "hPa";
     doc["device_class"] = "pressure";
   }


### PR DESCRIPTION
state_class: measurement was added for all sensor messages, but there were non-measurement sensors as well (status and detailed status) which then ceased to work. Changed implementation so that state_class is only added to measurement sensors.

So fixed few sensors and broke another, sorry about that, fixed now!